### PR TITLE
feat!: unexpose user facing commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
       "activitybar": [
         {
           "id": "scriptiq-settings",
-          "title": "Sauce Lab's ScriptIQ",
+          "title": "Sauce Labs ScriptIQ",
           "icon": "./media/icons/Lowcode_icon_white.png"
         }
       ]


### PR DESCRIPTION
## Description

Developers can define which of their [commands are user facing](https://code.visualstudio.com/api/extension-guides/command#creating-a-user-facing-command). We shouldn't prematurely expose commands. It's easier to add them, than to remove post-release. 