### PR TITLE
refactor: distinguish commands from actions

### DIFF
--- a/media/sidebar.js
+++ b/media/sidebar.js
@@ -24,7 +24,7 @@ function main() {
   startTestGeneration?.addEventListener('click', handleStartButtonClick);
   saveButton?.addEventListener('click', handleSaveClick);
   vscode.postMessage({
-    command: 'load-history-links',
+    action: 'load-history-links',
   });
 
   // createOutputLanguage();
@@ -32,7 +32,7 @@ function main() {
   // Handle messages sent from the extension or panel to the webview
   window.addEventListener('message', (event) => {
     const message = event.data; // The json data that the extension sent
-    switch (message.command) {
+    switch (message.action) {
       case 'settings-exist':
         usernameTextField.value = message.data.username;
         accessKeyTextField.value = message.data.accessKey;
@@ -60,7 +60,7 @@ function handleStartButtonClick() {
   // Send messages to Panel.
   resetHistoryLinkColor();
   vscode.postMessage({
-    command: 'show-test-generation-panel',
+    action: 'show-test-generation-panel',
   });
 }
 
@@ -76,7 +76,7 @@ function handleSaveClick() {
   };
   console.log(data);
   vscode.postMessage({
-    command: 'save-credentials',
+    action: 'save-credentials',
     data: data,
   });
 }
@@ -103,7 +103,7 @@ function createOutputLanguage() {
 
   languageScriptChoice.onclick = function () {
     vscode.postMessage({
-      command: 'load-language',
+      action: 'load-language',
       language: 'appium_python',
     });
   };
@@ -126,7 +126,7 @@ function createOutputLanguage() {
 
   languageScriptChoice.onclick = function () {
     vscode.postMessage({
-      command: 'load-language',
+      action: 'load-language',
       language: 'appium_java',
     });
   };
@@ -162,7 +162,7 @@ function createHistoryLinks(history_list, selected) {
       resetHistoryLinkColor();
       this.classList.add('history-selected');
       vscode.postMessage({
-        command: 'show-test-generation-panel',
+        action: 'show-test-generation-panel',
         data: history.testID,
       });
     };
@@ -174,7 +174,7 @@ function createHistoryLinks(history_list, selected) {
     trashButton.onclick = function () {
       console.log(history);
       vscode.postMessage({
-        command: 'delete-history',
+        action: 'delete-history',
         data: history.testID,
       });
     };

--- a/media/test-generation.js
+++ b/media/test-generation.js
@@ -95,7 +95,7 @@ function main() {
     console.log('LISTENER CREATED');
     window.addEventListener('message', (event) => {
       const message = event.data; // The json data that the extension sent
-      switch (message.command) {
+      switch (message.action) {
         case 'test':
           // Append answer.
           if ('status_message' in message.data) {
@@ -108,13 +108,13 @@ function main() {
             testGallery.appendChild(container);
           } else if ('finished' in message.data) {
             vscode.postMessage({
-              command: 'can-open-window',
+              action: 'can-open-window',
             });
           } else {
             testGallery.innerHTML = '';
             outputScript.innerHTML = '';
             vscode.postMessage({
-              command: 'save-steps',
+              action: 'save-steps',
               data: message.data,
             });
             updateStepDataState(message.data);
@@ -160,7 +160,7 @@ function handleAskClick() {
 
   // Send messages to Panel.
   vscode.postMessage({
-    command: 'press-generate-button',
+    action: 'press-generate-button',
     data: {
       goal: goalText.value,
       apk: apkText.value,
@@ -229,7 +229,7 @@ function generateFullTestDisplay() {
   var timeoutTime = 0;
   // if (!languageChange) {
   vscode.postMessage({
-    command: 'copy-image',
+    action: 'copy-image',
     testID: data.testID,
   });
   timeoutTime = 400;
@@ -638,7 +638,7 @@ function addEditTestInteractions(i, edit_data) {
 
     // Send messages to Panel.
     vscode.postMessage({
-      command: 'edit-test-button',
+      action: 'edit-test-button',
       data: {
         goal: newGoalInput.value,
         apk: edit_data.apk,
@@ -793,7 +793,7 @@ function sendUserRating(rating, step, testRecord) {
   console.log(`Sending User Rating for step ${step}: ${rating}`);
   // FIXME test record is missing step information (no step_data or all_steps)
   vscode.postMessage({
-    command: 'send-user-rating',
+    action: 'send-user-rating',
     data: { rating: rating, step: step, test_record: testRecord },
   });
 }

--- a/src/panels/sidebar.ts
+++ b/src/panels/sidebar.ts
@@ -51,7 +51,7 @@ export class SidebarViewProvider implements vscode.WebviewViewProvider {
    */
   private subscribeToWebviewEvents(webview: vscode.Webview) {
     webview.onDidReceiveMessage((message: any) => {
-      const command = message.command;
+      const command = message.action;
       let historyIndex = -1;
       switch (command) {
         case 'show-test-generation-panel':
@@ -120,13 +120,13 @@ export class SidebarViewProvider implements vscode.WebviewViewProvider {
   }
 
   public clearHistoryLinkSelection(): void {
-    this.view?.webview.postMessage({ command: 'clear-history-links' });
+    this.view?.webview.postMessage({ action: 'clear-history-links' });
   }
 
   public updateHistoryLinks(selected: number = -1): void {
     const history = this.store.getHistory();
     this.view?.webview.postMessage({
-      command: 'update-history-links',
+      action: 'update-history-links',
       data: history,
       selected: selected,
     });

--- a/src/panels/test-generation.ts
+++ b/src/panels/test-generation.ts
@@ -70,7 +70,7 @@ export class TestGenerationPanel {
         TestGenerationPanel.currentPanel.showTestRecord(testID);
       } else {
         TestGenerationPanel.currentPanel.panel.webview.postMessage({
-          command: 'clear',
+          action: 'clear',
         });
       }
     } else {
@@ -137,7 +137,7 @@ export class TestGenerationPanel {
   ) {
     webview.onDidReceiveMessage(
       (message: any) => {
-        const command = message.command;
+        const command = message.action;
 
         switch (command) {
           case 'press-generate-button':
@@ -385,7 +385,7 @@ export class TestGenerationPanel {
       '',
     ).subscribe((test) => {
       TestGenerationPanel.currentPanel?.panel.webview.postMessage({
-        command: 'test',
+        action: 'test',
         data: test,
       });
     });
@@ -431,7 +431,7 @@ export class TestGenerationPanel {
       prevGoal,
     ).subscribe((test) => {
       TestGenerationPanel.currentPanel?.panel.webview.postMessage({
-        command: 'test',
+        action: 'test',
         data: test,
       });
     });
@@ -477,7 +477,7 @@ export class TestGenerationPanel {
     }
 
     TestGenerationPanel.currentPanel?.panel.webview.postMessage({
-      command: 'history',
+      action: 'history',
       data: this.storage.getTestRecord(testID),
     });
   }


### PR DESCRIPTION
## Description

Rename the `command` field from messages that are sent from the Webviews.
This helps us distinguish vscode commands versus Webview message events that contain an action.