### PR TITLE
feat: Render the last "step" distinct from the rest

### DIFF
--- a/media/test-generation.js
+++ b/media/test-generation.js
@@ -234,7 +234,7 @@ function generateFullTestDisplay() {
       if ('user_screen_descs' in data) {
         user_screen_descs = data.user_screen_descs;
       }
-      console.log(all_step_data[i]);
+
       if (all_step_data[i].action === 'done') {
         renderDoneStep(data.test_id, data.img_ratio, all_step_data[i]);
       } else {


### PR DESCRIPTION
## Description

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

Even when specifying a step limit, the plugin was rendering `n+1`. The last step doesn't correspond to an action generated by the LM, its meant to show the user the final state of the app after the last action. This change labels the last step distinctly from the rest and only renders the screenshot. A bit unsure about the label/design, etc., but we can refine as needed.

### Old

![Screenshot 2024-03-20 at 7 55 52 PM](https://github.com/saucelabs/vscode-scriptiq/assets/56001373/ee123c7d-9d8b-46e3-91c9-a968ca83f0e7)


### New

![Screenshot 2024-03-20 at 7 55 19 PM](https://github.com/saucelabs/vscode-scriptiq/assets/56001373/6f57aa7e-4c22-42a3-9892-94e68d6ee86d)
