### PR TITLE
feat: added back reasoning and assertion info for final screen

### DIFF
--- a/media/test-generation.js
+++ b/media/test-generation.js
@@ -353,11 +353,7 @@ function generateStep(
   });
 
   const sectionHeader = document.createElement('h4');
-  if (final_screen) {
-    sectionHeader.append(`Finished`);
-  } else {
-    sectionHeader.append(`Step ${i + 1}`);
-  }
+  sectionHeader.append(finalScreen ? 'Finished' : `Step ${i + 1}`);
 
   const sectionBody = document.createElement('div');
   sectionBody.className = 'test-container';


### PR DESCRIPTION
Final screen needs reasonings to help users debug (it describes why the test is finished) and assertions to check whether the test has succeeded (the last step is often important for a test). I'm therefore adding those back by updating the generateStep function to include a flag for whether it is the final screen and changing the title and whether code is included based on this flag. 