### PR TITLE
feature: populate max steps field from record

### DIFF
--- a/media/test-generation.js
+++ b/media/test-generation.js
@@ -297,6 +297,7 @@ function generateFullTestDisplay() {
   const data = vscode.getState();
   appName.value = data.app_name;
   goalText.value = data.goal;
+  maxTestSteps.value = data.max_test_steps;
 
   assertContainer.innerHTML = '';
   if ('assert_screen_desc_container' in data) {


### PR DESCRIPTION
## Description

Was driving me crazy without this. The UI will now properly show what max steps were used in the record, which makes it now so much easier to retry, as I usually test with low limits, such as 3, whereas without this change, the UI would default back to 10.