### PR TITLE
Fix: Use wss protocol for staging/prod URL

### DIFF
--- a/src/api/llm/config.ts
+++ b/src/api/llm/config.ts
@@ -4,7 +4,7 @@ export function getWSServer(region: Region): string {
   if (process.env.NODE_ENV === 'development') {
     return 'ws://127.0.0.1:8000/v1';
   }
-  return `ws://${getDomain(region)}/v1/scriptiq-llm`;
+  return `wss://${getDomain(region)}/v1/scriptiq-llm`;
 }
 
 export function getHTTPServer(region: Region): string {


### PR DESCRIPTION
## Description

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

I'm not sure why `ws` occasionally worked on staging, but I've discovered it is blocked by Ambassador now. Using `wss` as the protocol resolves the issue and is now functioning correctly.
