### PR TITLE
fix: test record id mismatch when submitting feedback

### DIFF
--- a/src/api/llm/ws.ts
+++ b/src/api/llm/ws.ts
@@ -36,7 +36,6 @@ export function generateTest(
   platform: Platform,
   platformVersion: string,
   assertions: string[],
-  testID: string,
   prevGoal: string = '',
   creds: Credentials,
 ): [
@@ -73,7 +72,7 @@ export function generateTest(
     }
     const testRecord: TestRecord = {
       all_steps: [],
-      test_id: testID,
+      test_id: '',
       app_name: appName,
       goal: goal,
       user_screen_descs: assertions,
@@ -148,6 +147,8 @@ export function generateTest(
         if (isJobUpdateResponse(resp)) {
           console.log('Job created.');
           observer.next(resp);
+
+          testRecord.test_id = resp.result.job_id;
           testRecord.selected_device_name = resp.result.selected_device_name;
           testRecord.selected_platform_version =
             resp.result.selected_platform_version;
@@ -160,7 +161,7 @@ export function generateTest(
           console.log('Step created.');
           observer.next(resp);
           await downloadImage(
-            testID,
+            testRecord.test_id,
             resp.result.step.img_url,
             resp.result.step.img_name,
             username,

--- a/src/panels/test-generation.ts
+++ b/src/panels/test-generation.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { Uri } from 'vscode';
 import { sendUserRating } from '../api/llm/http';
 import { Memento } from '../memento';
 import { generateTest } from '../api/llm/ws';
@@ -9,10 +10,9 @@ import {
   executeClearHistoryLinkSelectionCommand,
   executeUpdateHistoryLinksCommand,
 } from '../commands';
-import { randomBytes, randomUUID } from 'node:crypto';
-import { Uri } from 'vscode';
+import { randomBytes } from 'node:crypto';
 import { WebSocket } from 'undici';
-import { Platform, Credentials } from '../types';
+import { Credentials, Platform } from '../types';
 
 const MAX_HISTORY_LEN = 100;
 
@@ -355,7 +355,6 @@ export class TestGenerationPanel {
       );
     }
 
-    const testID = this.createTestRecordID();
     this.testRecordNavigation = false;
 
     const [ws, observable] = generateTest(
@@ -370,7 +369,6 @@ export class TestGenerationPanel {
       platform,
       platformVersion,
       assertions,
-      testID,
       prevGoal,
       creds,
     );
@@ -415,10 +413,6 @@ export class TestGenerationPanel {
         toast.showError(err.message);
       },
     });
-  }
-
-  private createTestRecordID() {
-    return randomUUID().replaceAll('-', '');
   }
 
   private getCredentials(): Credentials | undefined {


### PR DESCRIPTION
## Description

The platform saves the test record independently of the client and uses the job ID as the primary key. This PR aligns the test ids with platform. Without this change, it'd be impossible to correctly reference the submitted feedback.