### PR TITLE
build!: add publisher id

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "type": "git",
     "url": "git+ssh://git@github.com/saucelabs/vscode-scriptiq.git"
   },
+  "publisher": "saucelabs-devx",
   "keywords": [
     "llm",
     "gpt",


### PR DESCRIPTION
## Description

Add VSCode Marketplace publisher ID, which is a required field for publishing this extension. I marked it as a breaking change, since the ID—previously `undefined`—affects where the extension stores its settings and test records. Prepare to start fresh ✨ ;)