### PR TITLE
refactor: clean up obsolete calls

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -17,10 +17,6 @@ export function executeShowTestGenerationPanelCommand(testID?: string) {
   vscode.commands.executeCommand(SHOW_TEST_GENERATION_PANEL_ID, testID);
 }
 
-// Clear the selection of test records in the history side panel.
-export const CLEAR_HISTORY_LINK_SELECTION_ID =
-  'scriptiq.clearHistoryLinkSelection';
-
 export function registerUpdateHistoryLinksCommand(
   ctx: vscode.ExtensionContext,
   callback: (selected?: number) => void,
@@ -37,16 +33,3 @@ export function executeUpdateHistoryLinksCommand(selected?: number) {
 // Update the history side panel with the latest test records. Optionally
 // accepts a `number` argument to select a specific test record.
 export const UPDATE_HISTORY_LINKS_ID = 'scriptiq.updateHistoryLinks';
-
-export function registerClearHistoryLinkSelectionCommand(
-  ctx: vscode.ExtensionContext,
-  callback: () => void,
-) {
-  ctx.subscriptions.push(
-    vscode.commands.registerCommand(CLEAR_HISTORY_LINK_SELECTION_ID, callback),
-  );
-}
-
-export function executeClearHistoryLinkSelectionCommand() {
-  vscode.commands.executeCommand(CLEAR_HISTORY_LINK_SELECTION_ID);
-}

--- a/src/panels/test-generation.ts
+++ b/src/panels/test-generation.ts
@@ -6,10 +6,7 @@ import { generateTest } from '../api/llm/ws';
 import * as toast from '../toast';
 import { GlobalStorage } from '../storage';
 import { errMsg } from '../error';
-import {
-  executeClearHistoryLinkSelectionCommand,
-  executeUpdateHistoryLinksCommand,
-} from '../commands';
+import { executeUpdateHistoryLinksCommand } from '../commands';
 import { randomBytes } from 'node:crypto';
 import { WebSocket } from 'undici';
 import { Credentials, Platform } from '../types';
@@ -314,7 +311,6 @@ export class TestGenerationPanel {
     prevGoal: string,
   ) {
     const creds = this.getCredentials();
-    executeClearHistoryLinkSelectionCommand();
     goal = goal.trim();
     appName = appName.trim();
 
@@ -421,8 +417,6 @@ export class TestGenerationPanel {
       toast.showError('Please add your credentials!');
       return creds;
     }
-
-    executeClearHistoryLinkSelectionCommand();
 
     if (!creds.username) {
       toast.showError('Please add your Username!');


### PR DESCRIPTION
## Description

The command `scriptiq.clearHistoryLinkSelection` no longer exists, which was used prior to our History panel changing to a native view. The call to this non-existent command would throw a benign error in the console, which will no longer be the case with this cleanup.