### PR TITLE
fix: python newline indent

### DIFF
--- a/webview-ui/test-generation/src/codegen/base.ts
+++ b/webview-ui/test-generation/src/codegen/base.ts
@@ -3,8 +3,7 @@ export abstract class AbstractBaseGenerator {
   protected preTab: string;
 
   constructor() {
-    this.preNewLine = `
-    `;
+    this.preNewLine = `\n`;
     this.preTab = `    `;
   }
 


### PR DESCRIPTION
## Description

The previous indent had an unwanted tab character. Switching hardcoded value to explicit newline character instead to avoid formatting issues in the future.