### PR TITLE
fix: better attempts at image download

### DIFF
--- a/src/api/llm/http.ts
+++ b/src/api/llm/http.ts
@@ -16,7 +16,7 @@ export async function downloadImage(
   accessKey: string,
   storage: GlobalStorage,
 ) {
-  for (let attempt = 0; attempt < 10; attempt++) {
+  for (let attempt = 0; attempt < 15; attempt++) {
     if (attempt > 0) {
       console.log('Retrying image download...');
       await new Promise((f) => setTimeout(f, 3000));


### PR DESCRIPTION
## Description

The current wait time of `1s` paired with 10 retries means that we're giving the very first screenshot only **10 seconds** to show up after the job has finished. In practice, we've observed this to be not enough. Increase this threshold to effectively **45 seconds**.