### PR TITLE
fix: more flexible wrap patterns for commands

### DIFF
--- a/webview-ui/test-generation/src/TestStep.scss
+++ b/webview-ui/test-generation/src/TestStep.scss
@@ -114,7 +114,13 @@ section.test-step {
 .commands {
   .command {
     margin: 4px;
+
+    code {
+      display: flex;
+      flex-wrap: wrap;
+    }
   }
+
   .alternatives {
     .toggle {
       display: flex;


### PR DESCRIPTION
## Description

Commands can be quite long, particularly the xpath string values. This can cause elements to overflow unequally:

![Overflow Test Steps](https://github.com/saucelabs/vscode-scriptiq/assets/1869292/b59b7fc6-4f64-49e7-a4dc-b2e0085b560c)

I was trying to have all test steps overflow in the same manner, but wasn't ultimately able to ☹️ .
Instead, I made the entire code block `flex`. It seems to work well enough, in that it's readable still, because majority of the elements in there (the amount varies between java and python) are wrapped in `span` tags.

All in all, we'll still overflow inconsistently between the test steps, but allow for more flexibility in breaking apart the command before doing so.
<img width="861" alt="SCR-20240708-oqkh" src="https://github.com/saucelabs/vscode-scriptiq/assets/1869292/b2322e6c-accd-465f-9422-bb84b7283150">