### PR TITLE
chore!: change publisher id

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "type": "git",
     "url": "git+ssh://git@github.com/saucelabs/vscode-scriptiq.git"
   },
-  "publisher": "saucelabs-devx",
+  "publisher": "saucelabs",
   "icon": "media/icons/Lowcode_icon_storefront.png",
   "keywords": [
     "llm",


### PR DESCRIPTION
## Description

Change the publisher ID. This is a breaking change, because vscode uses the publisher ID in the storage path. Meaning, after this change, existing connection settings and test records will be reset.