### PR TITLE
fix: missing icons

### DIFF
--- a/webview-ui/test-generation/vite.config.mts
+++ b/webview-ui/test-generation/vite.config.mts
@@ -14,6 +14,7 @@ export default defineConfig({
   mode: 'development',
   build: {
     outDir: 'build',
+    assetsInlineLimit: 12288, // DEVX-2976: Workaround for missing assets.
     rollupOptions: {
       output: {
         entryFileNames: `assets/[name].js`,


### PR DESCRIPTION
## Description

`vite` inlines assets by default up to the limit of 4k bytes. Our assets are currently not properly available otherwise, hence the hot fix to increase the inline limit to 12k.