### PR TITLE
fix: updating code to find_element in set_text 

### DIFF
--- a/webview-ui/test-generation/src/codegen/java.ts
+++ b/webview-ui/test-generation/src/codegen/java.ts
@@ -59,6 +59,7 @@ export class AppiumJava extends AbstractBaseGenerator {
   sendTextCode(text: string, platform: string, number = '', findElement = '') {
     if (platform == 'Android') {
       return `            element${number}.click();
+            ${findElement.replace('WebElement ', '').replace('\n', '')}
             element${number}.sendKeys("${text}");
             ((PressesKey) driver).pressKey(new KeyEvent(AndroidKey.ENTER));\n`;
     } else {

--- a/webview-ui/test-generation/src/codegen/python.ts
+++ b/webview-ui/test-generation/src/codegen/python.ts
@@ -56,6 +56,7 @@ export class AppiumPython extends AbstractBaseGenerator {
   sendTextCode(text: string, platform: string, findElement = '') {
     if (platform == 'Android') {
       return `    element.click()
+    ${findElement.replace('\n', '')} 
     element.send_keys("${text}")
     driver.execute_script('mobile: performEditorAction', {'action': 'Go'})
     driver.execute_script('mobile: performEditorAction', {'action': 'Search'})\n`;


### PR DESCRIPTION
Updating code to match backend so will replay the same way. This, for Android, calls the find_element before sending keys when sending text to device. 