### PR TITLE
fix: backward compatible tunnel settings

### DIFF
--- a/webview-ui/test-generation/src/App.tsx
+++ b/webview-ui/test-generation/src/App.tsx
@@ -296,8 +296,8 @@ function App() {
                   devices: state.device ? [state.device] : [],
                   platform: platform.name,
                   platform_version: platform.version,
-                  tunnel_name: tunnel?.name,
-                  tunnel_owner: tunnel?.owner,
+                  tunnel_name: tunnel?.name ?? '',
+                  tunnel_owner: tunnel?.owner ?? '',
                 },
               });
             }}


### PR DESCRIPTION
## Description

Tunnel name and owner have to be always defined. Test records that were saved prior to the newly added tunnel support, did not have this field. If you load a previous test record, ScriptIQ throws an error requiring you to specify a tunnel.