### PR TITLE
fix: Don't draw orange border when re-rendering screenshot

### DIFF
--- a/webview-ui/test-generation/src/Screenshot.tsx
+++ b/webview-ui/test-generation/src/Screenshot.tsx
@@ -25,10 +25,11 @@ export function Screenshot(props: ScreenshotProps) {
     if (!context) {
       return;
     }
+
     const img = new Image();
     img.src = src;
 
-    img.onload = () => {
+    const onload = () => {
       context.drawImage(img, 0, 0, imgWidth, imgHeight);
 
       if (annotation) {
@@ -44,6 +45,18 @@ export function Screenshot(props: ScreenshotProps) {
         context.stroke();
       }
     };
-  }, [ref, annotation, src, imgWidth, imgHeight]);
+    img.addEventListener('load', onload);
+
+    return () => img.removeEventListener('load', onload);
+  }, [
+    ref,
+    annotation.x,
+    annotation.y,
+    annotation.width,
+    annotation.height,
+    src,
+    imgWidth,
+    imgHeight,
+  ]);
   return <canvas ref={ref} width={imgWidth} height={imgHeight} />;
 }

--- a/webview-ui/test-generation/src/Screenshot.tsx
+++ b/webview-ui/test-generation/src/Screenshot.tsx
@@ -31,8 +31,6 @@ export function Screenshot(props: ScreenshotProps) {
     img.onload = () => {
       context.drawImage(img, 0, 0, imgWidth, imgHeight);
 
-      context.strokeRect(0, 0, imgWidth, imgHeight);
-
       if (annotation) {
         context.lineWidth = 3;
         context.rect(


### PR DESCRIPTION
## Description

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->
* Remove the border on the screenshot, it is not needed according to latest designs.
* The effect to draw the annotation was executing unnecessarily. Give the effect a proper list of dependencies to prevent unnecessary calls.
* Properly cleanup event handler in the case the effect does run again.

[DEVX-2933]

[DEVX-2933]: https://saucedev.atlassian.net/browse/DEVX-2933?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ