### PR TITLE
fix: Always set an appName if the app list is populated

### DIFF
--- a/webview-ui/test-generation/src/state.ts
+++ b/webview-ui/test-generation/src/state.ts
@@ -374,9 +374,8 @@ export const reducer = (current: State, action: Action): State => {
         apps.sort((a, b) => a.name.localeCompare(b.name));
       }
 
-      // NOTE: Avoid assigning an empty string to appName
-      // since the VSCodeDropdown won't show an empty selection
-      // after its options are populated after first render.
+      // NOTE: Since the VSCodeDropdown can't show an empty selection if its not empty,
+      // avoid assigning an empty string to appName when the apps list is not empty.
       let appName = current.appName;
       if (apps.length > 0 && appName === '') {
         appName = apps[0].name;

--- a/webview-ui/test-generation/src/state.ts
+++ b/webview-ui/test-generation/src/state.ts
@@ -374,8 +374,17 @@ export const reducer = (current: State, action: Action): State => {
         apps.sort((a, b) => a.name.localeCompare(b.name));
       }
 
+      // NOTE: Avoid assigning an empty string to appName
+      // since the VSCodeDropdown won't show an empty selection
+      // after its options are populated after first render.
+      let appName = current.appName;
+      if (apps.length > 0 && appName === '') {
+        appName = apps[0].name;
+      }
+
       return {
         ...current,
+        appName,
         apps: apps,
       };
     }


### PR DESCRIPTION


## Description

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

The VSCodeDropdown component can't show an empty selection if it has any options. Since the app list is populated after a fetch, the dropdown will default to selecting the first element even if appName in state is an empty string.

[DEVX-3070]

[DEVX-3070]: https://saucedev.atlassian.net/browse/DEVX-3070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ