### PR TITLE
fix: Make sure the correct record is selected after an execution

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -19,15 +19,15 @@ export function executeShowTestGenerationPanelCommand(testID?: string) {
 
 export function registerUpdateHistoryLinksCommand(
   ctx: vscode.ExtensionContext,
-  callback: (selected?: number) => void,
+  callback: (testID?: string) => void,
 ) {
   ctx.subscriptions.push(
     vscode.commands.registerCommand(UPDATE_HISTORY_LINKS_ID, callback),
   );
 }
 
-export function executeUpdateHistoryLinksCommand(selected?: number) {
-  vscode.commands.executeCommand(UPDATE_HISTORY_LINKS_ID, selected);
+export function executeUpdateHistoryLinksCommand(testID?: string) {
+  vscode.commands.executeCommand(UPDATE_HISTORY_LINKS_ID, testID);
 }
 
 // Update the history side panel with the latest test records. Optionally

--- a/src/editors/TestGenerationPanel.ts
+++ b/src/editors/TestGenerationPanel.ts
@@ -392,7 +392,7 @@ export class TestGenerationPanel {
       toast.showError(`Failed to add test record to history: ${errMsg(e)}`);
     }
 
-    executeUpdateHistoryLinksCommand(0);
+    executeUpdateHistoryLinksCommand(testID);
   }
 
   private getCredentials(): Credentials | undefined {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -54,12 +54,9 @@ export async function activate(context: vscode.ExtensionContext) {
   );
 
   const historyProvider = new HistoryProvider(storage, memento);
-  context.subscriptions.push(
-    vscode.window.registerTreeDataProvider(
-      HistoryProvider.viewType,
-      historyProvider,
-    ),
-  );
+  const historyTree = vscode.window.createTreeView(HistoryProvider.viewType, {
+    treeDataProvider: historyProvider,
+  });
 
   context.subscriptions.push(
     vscode.commands.registerCommand(
@@ -76,8 +73,15 @@ export async function activate(context: vscode.ExtensionContext) {
     }),
   );
 
-  registerUpdateHistoryLinksCommand(context, () => {
+  registerUpdateHistoryLinksCommand(context, (testID?: string) => {
     historyProvider.refresh();
+
+    if (testID) {
+      const testRecord = storage.getTestRecord(testID);
+      if (testRecord) {
+        historyTree.reveal(testRecord, { select: true, focus: true });
+      }
+    }
   });
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -78,9 +78,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
     if (testID) {
       const testRecord = storage.getTestRecord(testID);
-      if (testRecord) {
-        historyTree.reveal(testRecord, { select: true, focus: true });
-      }
+      historyTree.reveal(testRecord, { select: true, focus: true });
     }
   });
 }

--- a/src/sidebars/history.ts
+++ b/src/sidebars/history.ts
@@ -1,20 +1,13 @@
 import * as vscode from 'vscode';
-import * as path from 'node:path';
 
 import { Memento } from '../memento';
 import { GlobalStorage } from '../storage';
-import { TestStep, TestRecord } from '../types';
+import { TestRecord } from '../types';
 import * as toast from '../toast';
 import { errMsg } from '../error';
 import { executeShowTestGenerationPanelCommand } from '../commands';
 
-function isTestRecord(maybe: TestStep | TestRecord): maybe is TestRecord {
-  return 'app_name' in maybe;
-}
-
-export class HistoryProvider
-  implements vscode.TreeDataProvider<TestStep | TestRecord>
-{
+export class HistoryProvider implements vscode.TreeDataProvider<TestRecord> {
   public static readonly viewType = 'scriptiq-history';
 
   constructor(
@@ -23,55 +16,31 @@ export class HistoryProvider
   ) {}
 
   getTreeItem(
-    element: TestStep | TestRecord,
+    element: TestRecord,
   ): vscode.TreeItem | Thenable<vscode.TreeItem> {
-    if (isTestRecord(element)) {
-      return new TestRecordItem(element);
-    }
-    return new TestStepItem(element);
+    return new TestRecordItem(element);
   }
 
   getChildren(
-    element?: TestStep | TestRecord | undefined,
-  ): vscode.ProviderResult<TestRecord[] | TestStep[]> {
-    if (element) {
-      if (isTestRecord(element)) {
-        return element.all_steps;
-      }
-    } else {
-      const ids = this._memento.getTestIDs();
-      const testRecords = this._storage.getTestRecords(ids);
-
-      return testRecords;
-    }
-  }
-
-  getParent(
-    element: TestStep | TestRecord,
-  ): vscode.ProviderResult<TestStep | TestRecord> {
-    if (isTestRecord(element)) {
-      return null;
-    }
+    _element?: TestRecord | undefined,
+  ): vscode.ProviderResult<TestRecord[]> {
     const ids = this._memento.getTestIDs();
     const testRecords = this._storage.getTestRecords(ids);
 
-    // NOTE: A TestStep has no explicit reference to its TestRecord
-    // so we're finding its parent using TestStep's img_url. img_url
-    // contains the jobID so it should be unique enough to find the
-    // parent TestRecord
-    const parent = testRecords.find((tr) => {
-      tr.all_steps?.some((step) => step.img_url === element.img_url);
-    });
-    return parent;
+    return testRecords;
+  }
+
+  getParent(_element: TestRecord): vscode.ProviderResult<TestRecord> {
+    return null;
   }
 
   private _onDidChangeTreeData: vscode.EventEmitter<
-    void | TestStep | TestRecord | (TestStep | TestRecord)[] | null | undefined
+    void | TestRecord | TestRecord[] | null | undefined
   > = new vscode.EventEmitter<
-    void | TestStep | TestRecord | (TestStep | TestRecord)[] | null | undefined
+    void | TestRecord | TestRecord[] | null | undefined
   >();
   readonly onDidChangeTreeData: vscode.Event<
-    void | TestStep | TestRecord | (TestStep | TestRecord)[] | null | undefined
+    void | TestRecord | TestRecord[] | null | undefined
   > = this._onDidChangeTreeData.event;
 
   refresh(): void {
@@ -117,7 +86,7 @@ export class HistoryProvider
 
 class TestRecordItem extends vscode.TreeItem {
   constructor(record: TestRecord) {
-    super(record.app_name, vscode.TreeItemCollapsibleState.Collapsed);
+    super(record.app_name, vscode.TreeItemCollapsibleState.None);
 
     this.contextValue = 'testRecord';
     this.command = {
@@ -126,19 +95,4 @@ class TestRecordItem extends vscode.TreeItem {
       title: 'Show Test',
     };
   }
-}
-
-class TestStepItem extends vscode.TreeItem {
-  constructor(step: TestStep) {
-    super(step.event_reason, vscode.TreeItemCollapsibleState.None);
-  }
-
-  iconPath = path.join(
-    __filename,
-    '..',
-    '..',
-    'media',
-    'icons',
-    'icn-edit-file-outline.svg',
-  );
 }

--- a/src/sidebars/history.ts
+++ b/src/sidebars/history.ts
@@ -51,19 +51,18 @@ export class HistoryProvider
   ): vscode.ProviderResult<TestStep | TestRecord> {
     if (isTestRecord(element)) {
       return null;
-    } else {
-      const ids = this._memento.getTestIDs();
-      const testRecords = this._storage.getTestRecords(ids);
-
-      // NOTE: A TestStep has no explicit reference to its TestRecord
-      // so we're finding its parent using TestStep's img_url. img_url
-      // contains the jobID so it should be unique enough to find the
-      // parent TestRecord
-      const parent = testRecords.find((tr) => {
-        tr.all_steps?.some((step) => step.img_url === element.img_url);
-      });
-      return parent;
     }
+    const ids = this._memento.getTestIDs();
+    const testRecords = this._storage.getTestRecords(ids);
+
+    // NOTE: A TestStep has no explicit reference to its TestRecord
+    // so we're finding its parent using TestStep's img_url. img_url
+    // contains the jobID so it should be unique enough to find the
+    // parent TestRecord
+    const parent = testRecords.find((tr) => {
+      tr.all_steps?.some((step) => step.img_url === element.img_url);
+    });
+    return parent;
   }
 
   private _onDidChangeTreeData: vscode.EventEmitter<


### PR DESCRIPTION
## Description

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

Select the correct test record in the tree after a test run completes.

Using the TreeView's `reveal` api requires the data provider to implement the optional `getParent` method. The implementation I added is going to look a little strange since I couldn't find an explicit reference from a TestStep to its parent TestRecord. The implementation uses `img_url` as the way to map them since `img_url` contains the jobID in the path. We're not actually using the `reveal` api to currently select TestSteps though, only TestRecords. So the implementation in this PR is technically not necessary. The alternative is to just return `null` which signals to the TreeView the item being revealed is a child of the root (i.e. TestRecord). Both not ideal! So I'm open to whichever one the team thinks is less confusing.

[DEVX-3071]

[DEVX-3071]: https://saucedev.atlassian.net/browse/DEVX-3071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ